### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,12 @@
       {
         "url": "https://feedback-app-proxy.deskpro.workers.dev/",
         "methods": ["POST"],
-        "timeout": 10
+        "timeout": 10,
+        "settingsInjection": {
+          "api_key": {
+            "header": ["Authorization"]
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
This pull request introduces a configuration change to the `manifest.json` file to support secure API key injection for outgoing requests. The update enables the app to automatically include the API key in the `Authorization` header when making POST requests to the specified proxy URL.

API integration improvements:

* Added a `settingsInjection` section to the proxy configuration, specifying that the `api_key` should be injected into the `Authorization` header for outgoing requests to `https://feedback-app-proxy.deskpro.workers.dev/`.